### PR TITLE
sort items by season / episode

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,13 @@ $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+uasort($data, function($a, $b) {
+	if($a['season'] === $b['season']) {
+		return $a['episode'] <=> $b['episode'];
+	}
+	
+	return $a['season'] <=> $b['season'];
+});
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);


### PR DESCRIPTION
This PR updates the sort order of the episodes so they appear in ASC season / episode order.

---

**Testing**

In a browser, open inspector, find the css rule for "h4 small" element, change color to "pink" and make sure all episodes are sorted by season / episode.  

---

**Deployment steps**

Merge branch `issue1` into `master`
