### PR TITLE
add simple guzzle error handling

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,14 +4,19 @@ require_once '../vendor/autoload.php';
 //Load Twig templating environment
 $loader = new Twig_Loader_Filesystem('../templates/');
 $twig = new Twig_Environment($loader, ['debug' => true]);
+$isError = false;
 
 //Get the episodes from the API
-$client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
+try {
+	$client = new GuzzleHttp\Client();
+	$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+	$data = json_decode($res->getBody(), true);
 
-//Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
-
+	//Sort the episodes
+	array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+}
+catch(\GuzzleHttp\Exception\ServerException $e) {
+	$isError = true;
+}
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+echo $twig->render('page.html', ["episodes" => $data, 'isError' => $isError]);

--- a/templates/page.html
+++ b/templates/page.html
@@ -13,17 +13,25 @@
         <p><img class="img-circle" src="resources/img/bobby.jpg"></p>
       </div>
     </div>
+	
+	<div class="container">
+		{% if isError %}
+			<div class='row'>
+				<div class="col-md-12">
+					<p class="alert alert-danger">Sorry, there was an error. Please try again by reloading the page.</p>
+				</div>
+			</div>
+		{% else %}
+			{% for episode in episodes %}
+				{% if loop.index%2 == 1 %}<div class="row">{%endif %}
 
-    <div class="container">
-        {% for episode in episodes %}
-            {% if loop.index%2 == 1 %}<div class="row">{%endif %}
+					{{ include('episode.html') }}
 
-                {{ include('episode.html') }}
-        
-            {% if loop.index%2 == 0 %}</div>{%endif %}
-        {% endfor %}
-    </div>
-
+				{% if loop.index%2 == 0 %}</div>{%endif %}
+			{% endfor %}
+		{% endif %}
+	</div>
+	
     <footer class="footer">
       <div class="container-fluid">
           <div class="row">


### PR DESCRIPTION
Tell us what you did e.g.

This PR updates adds a very simple error checking against guzzlehttp serverexception. If things go wrong a nice message is displayed instead of everything exploding.
---

**Testing**

Since you have access to the api and it's only test you can test the code easily by returning 500 from the api and confirm you can see the error message. More sane option would be to manually throw an exception instead of calling the api. In a perfect world there would be a unit test, but since we're talking 5 lines of code here, with no classes, this solution would not apply here.

---

**Deployment steps**

Merge branch `issue2` into `master`
