### PR TITLE
show only one popover at a time

### DIFF
--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -13,7 +13,10 @@ module.exports = function () {
         selector: '[data-toggle="popover"]',
         container: 'body',
         viewport: { selector: 'body', padding: 20 }
-    })
+    }).on('show.bs.popover', function (e) {
+		$('[data-toggle="popover"]').not(e.target).popover("destroy");
+		$(".popover").remove(); 
+	})
     
     // Initialise Bootstrap tooltips
     //http://getbootstrap.com/javascript/#tooltips


### PR DESCRIPTION
This PR updates the popover plugin so that only one popover can be displayed at a time.

---

**Testing**
Click on one thumbnail and then click another. If number of popovers === 1 then life is good.

---

**Deployment steps**

Merge branch `issue4` into `master`

Compile assets: `./bin/node_modules/gulp`
